### PR TITLE
Health Check changes to ensure correct status

### DIFF
--- a/.deploy/Validate-Deployment.ps1
+++ b/.deploy/Validate-Deployment.ps1
@@ -83,7 +83,7 @@ Write-Host "[2/6] Checking C# API..." -ForegroundColor Yellow
 try {
     $health = Invoke-RestMethod -Uri "$CsharpApiUrl/health" -Method Get -TimeoutSec 5
     
-    if ($health.status -eq "Healthy") {
+    if ($health.status -eq "healthy") {
         Write-Host "✓ C# API is healthy" -ForegroundColor Green
         $checks += @{ Name = "C# API Health"; Status = "PASS" }
     }

--- a/.devcontainer/validate.ps1
+++ b/.devcontainer/validate.ps1
@@ -366,7 +366,7 @@ try {
 # Test C# API if running
 try {
     $health = Invoke-RestMethod -Uri "http://localhost:5000/health" -Method Get -TimeoutSec 3
-    if ($health.status -eq "Healthy") {
+    if ($health.status -eq "healthy") {
         Write-Success "C# API: Health endpoint responsive on port 5000"
     } else {
         Write-Warning "C# API: Health endpoint returned unexpected status: $($health.status)"

--- a/.devcontainer/validate.sh
+++ b/.devcontainer/validate.sh
@@ -348,7 +348,7 @@ fi
 if curl -f -s --max-time 3 http://localhost:5000/health >/dev/null 2>&1; then
     # Get actual health response
     health_response=$(curl -s --max-time 3 http://localhost:5000/health)
-    if echo "$health_response" | grep -q '"status":"Healthy"'; then
+    if echo "$health_response" | grep -q '"status":"healthy"'; then
         print_success "C# API: Health endpoint responsive on port 5000"
     else
         print_warning "C# API: Health endpoint returned unexpected response"


### PR DESCRIPTION
This pull request updates the health check logic for the C# API in deployment and validation scripts to expect the status value "healthy" (lowercase) instead of "Healthy" (capitalized). This ensures consistency with the API's actual response and prevents false negatives during health checks.

**Health check updates:**

* [`.deploy/Validate-Deployment.ps1`](diffhunk://#diff-70561d48a867ea5a977d6802daa098228e3372c7bad4eb58a5d357fcc054a6cdL86-R86): Changed the health status comparison from "Healthy" to "healthy" in the C# API health check.
* [`.devcontainer/validate.ps1`](diffhunk://#diff-a5531ea3298ba7fcf888734de33607dc9dd9a8999ce2435aa0a3495077a745b9L369-R369): Updated the health status check to expect "healthy" instead of "Healthy" when validating the C# API.
* [`.devcontainer/validate.sh`](diffhunk://#diff-2bd3fc6d857e6b70090c6c6996442b2dfc37dd6f63a1f28d0ea13eca5bb4ccb9L351-R351): Modified the grep pattern to look for `"status":"healthy"` instead of `"status":"Healthy"` in the C# API health response.