### PR TITLE
deps: bump container base images to fix CVEs

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ version: '3.8'
 services:
   # RabbitMQ for message queue development
   rabbitmq-dev:
-    image: rabbitmq:3.13-management
+    image: rabbitmq:4.1-management
     container_name: rabbitmq-dev
     ports:
       - "5672:5672"   # AMQP port
@@ -26,7 +26,7 @@ services:
 
   # Optional: Redis for caching/session management
   redis-dev:
-    image: redis:7-alpine
+    image: redis:7.2.14-alpine
     container_name: redis-dev
     ports:
       - "6379:6379"
@@ -39,7 +39,7 @@ services:
 
   # Optional: PostgreSQL for data persistence
   postgres-dev:
-    image: postgres:16-alpine
+    image: postgres:17-alpine
     container_name: postgres-dev
     ports:
       - "5432:5432"

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -6,7 +6,7 @@ version: "3.8"
 
 services:
   rabbitmq:
-    image: rabbitmq:3.13-management
+    image: rabbitmq:4.1-management
     container_name: rabbitmq
     ports:
       - "5672:5672" # AMQP port

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ version: "3.8"
 
 services:
   rabbitmq:
-    image: rabbitmq:3.13-management
+    image: rabbitmq:4.1-management
     container_name: rabbitmq
     ports:
       - "5672:5672" # AMQP port

--- a/src/k8s/local/rabbitmq-local.yaml
+++ b/src/k8s/local/rabbitmq-local.yaml
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
       - name: rabbitmq
-        image: rabbitmq:3.13-management
+        image: rabbitmq:4.1-management
         ports:
         - containerPort: 5672
           name: amqp

--- a/src/k8s/rabbitmq-deployment.yaml
+++ b/src/k8s/rabbitmq-deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: rabbitmq
-        image: rabbitmq:3.13-management
+        image: rabbitmq:4.1-management
         ports:
         - containerPort: 5672
           name: amqp

--- a/src/rust-api/Dockerfile
+++ b/src/rust-api/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:1.92-alpine AS builder
+FROM rust:1.96-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache musl-dev
@@ -22,7 +22,7 @@ COPY src ./src
 RUN touch src/main.rs && cargo build --release
 
 # Runtime stage
-FROM alpine:3.21
+FROM alpine:3.22
 
 # Install runtime dependencies and apply OS-level security patches
 RUN apk upgrade --no-cache && \


### PR DESCRIPTION
Bumps container base images to fix CVEs surfaced by the new Trivy scan workflow in #25.

## Image bumps
| File(s) | Before | After | Why |
|---|---|---|---|
| `src/rust-api/Dockerfile` | `rust:1.92-alpine` | `rust:1.96-alpine` | Current stable (May 2026) |
| `src/rust-api/Dockerfile` | `alpine:3.21` | `alpine:3.22` | 3.21 security EOL Nov 2026 |
| `docker-compose.yml`, `docker-compose.full.yml`, `.devcontainer/docker-compose.yml`, `src/k8s/rabbitmq-deployment.yaml`, `src/k8s/local/rabbitmq-local.yaml` | `rabbitmq:3.13-management` | `rabbitmq:4.1-management` | 3.13 community EOL Sep 2024 |
| `.devcontainer/docker-compose.yml` | `redis:7-alpine` | `redis:7.2.14-alpine` | Fixes CVE-2026-23479, CVE-2026-25243, CVE-2026-23631 (all RCE) |
| `.devcontainer/docker-compose.yml` | `postgres:16-alpine` | `postgres:17-alpine` | Clears critical CVE-2025-68121 + 16 high CVEs; 17 supported through Nov 2029 |

## Why no .NET bump
The .NET 10 `FROM` lines use the rolling `:10.0` / `:10.0-alpine` tags. A rebuild automatically picks up 10.0.8 (CVE-2026-40372 fix in DataProtection). No file change needed.

## Breaking-change risk
**RabbitMQ 4.x is a major version bump.** The compose/k8s healthchecks (`rabbitmq-diagnostics ping`) and `RABBITMQ_DEFAULT_USER/PASS` env vars still work in 4.x, but verify before merging if you rely on:
- Classic mirrored queues (removed in 4.0 - use quorum queues)
- Older feature flags (some are mandatory in 4.x)
- Custom plugins or specific Erlang versions

## Verification
Once merged, the container-scan workflow from #25 will rerun and the open Code Scanning alerts for these images should clear.

Related: #25