### PR TITLE
ci(scan): add devcontainer base image; align matrix with PR #26 versions

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -115,9 +115,10 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - rabbitmq:3.13-management
-          - redis:7-alpine
-          - postgres:16-alpine
+          - rabbitmq:4.1-management
+          - redis:7.2.14-alpine
+          - postgres:17-alpine
+          - mcr.microsoft.com/devcontainers/universal:2
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Closes the remaining devcontainer-scanning gap surfaced after #25 / #26.

## Why
- The third-party scan matrix still referenced the pre-#26 tags (`rabbitmq:3.13-management`, `redis:7-alpine`, `postgres:16-alpine`) — those are no longer used anywhere in the repo, so the alerts they generated were noise.
- The devcontainer base image (`mcr.microsoft.com/devcontainers/universal:2`) was never scanned. It picks up patches implicitly on rebuild, but we had zero CVE visibility for it in Code Scanning.

## Change
`.github/workflows/container-scan.yml` third-party matrix:

` diff
- rabbitmq:3.13-management
- redis:7-alpine
- postgres:16-alpine
+ rabbitmq:4.1-management
+ redis:7.2.14-alpine
+ postgres:17-alpine
+ mcr.microsoft.com/devcontainers/universal:2
`

## Local
Also ran `docker pull mcr.microsoft.com/devcontainers/universal:2` — the local cache was already current (digest `sha256:dca6a985…`). To actually pick up patched layers in your running devcontainer you still need *Dev Containers: Rebuild Container (no cache)* in VS Code.

Related: #25, #26