### PR TITLE
docs(labs): validate labs, fix Lab 2 k8s names, add 'Lab Version' checkout sections

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 # Development container services
 # This compose file is used by the dev container for local development services
 

--- a/Labs/Lab1.RustAksDemo.md
+++ b/Labs/Lab1.RustAksDemo.md
@@ -11,8 +11,28 @@ deploy the services to an AKS cluster:
 
 Both APIs are containerized and ready for deployment to Azure Kubernetes Service (AKS).
 
+## Lab Version
+
+This lab is stabilized on the **`lab1-v1.0`** tag and the **`labs/lab1`** branch.
+
+To follow this lab against a known-good snapshot of the repository:
+
+```powershell
+git fetch --tags
+git checkout lab1-v1.0
+```
+
+To make changes while following along, create a working branch from the tag:
+
+```powershell
+git checkout -b my-lab1-work lab1-v1.0
+```
+
+For the latest in-progress version of the lab, use the `main` branch or the long-lived `labs/lab1` branch (which tracks the tip of this lab).
+
 ## Table of Contents
 
+- [Lab Version](#lab-version)
 - [Prerequisites](#prerequisites)
 - [High Level Architecture](#high-level-architecture)
 - [RESTful API Services](#restful-api-services)

--- a/Labs/Lab2.MessageQueue.md
+++ b/Labs/Lab2.MessageQueue.md
@@ -11,8 +11,28 @@ The system consists of:
 
 This lab demonstrates cloud-native patterns including message queuing, worker pools, and auto-scaling in Kubernetes.
 
+## Lab Version
+
+This lab is stabilized on the **`lab2-v1.0`** tag and the **`labs/lab2`** branch.
+
+To follow this lab against a known-good snapshot of the repository:
+
+```powershell
+git fetch --tags
+git checkout lab2-v1.0
+```
+
+To make changes while following along, create a working branch from the tag:
+
+```powershell
+git checkout -b my-lab2-work lab2-v1.0
+```
+
+For the latest in-progress version of the lab, use the `main` branch or the long-lived `labs/lab2` branch (which tracks the tip of this lab).
+
 ## Table of Contents
 
+- [Lab Version](#lab-version)
 - [Prerequisites](#prerequisites)
 - [Architecture Overview](#architecture-overview)
 - [Message Format and Flow](#message-format-and-flow)

--- a/Labs/Lab2.MessageQueue.md
+++ b/Labs/Lab2.MessageQueue.md
@@ -443,7 +443,7 @@ worker-service      (new)
 (Get-Content src/k8s/worker-deployment.yaml) -replace '<your-acr-name>', $ACR_NAME | Set-Content src/k8s/worker-deployment.yaml
 
 # Update Rust API deployment (if not already updated)
-(Get-Content src/k8s/rust-api-mq-deployment.yaml) -replace '<your-acr-name>', $ACR_NAME | Set-Content src/k8s/rust-api-mq-deployment.yaml
+(Get-Content src/k8s/rust-deployment.yaml) -replace '<your-acr-name>', $ACR_NAME | Set-Content src/k8s/rust-deployment.yaml
 ```
 
 ### 2.3 Create Kubernetes Secrets
@@ -498,11 +498,11 @@ kubectl logs -l app=rabbitmq -n hello-apis --tail=50
 kubectl apply -f src/k8s/rust-deployment.yaml
 
 # Wait for pods to be ready
-kubectl wait --for=condition=ready pod -l app=rust-api-mq -n hello-apis --timeout=300s
+kubectl wait --for=condition=ready pod -l app=rust-hello-api -n hello-apis --timeout=300s
 
 # Check API status
-kubectl get pods -l app=rust-api-mq -n hello-apis
-kubectl get svc rust-api-mq -n hello-apis
+kubectl get pods -l app=rust-hello-api -n hello-apis
+kubectl get svc rust-hello-api -n hello-apis
 ```
 
 ### 2.6 Deploy Worker Service
@@ -549,7 +549,7 @@ kubectl get pods -n hello-apis
 # Expected output:
 # NAME                              READY   STATUS    RESTARTS   AGE
 # rabbitmq-0                        1/1     Running   0          5m
-# rust-api-mq-xxx                   1/1     Running   0          3m
+# rust-hello-api-xxx                   1/1     Running   0          3m
 # worker-service-xxx                1/1     Running   0          2m
 
 # Check all services
@@ -565,10 +565,10 @@ kubectl get hpa -n hello-apis
 
 ```powershell
 # Wait for external IP to be assigned
-kubectl get svc rust-api-mq -n hello-apis -w
+kubectl get svc rust-hello-api -n hello-apis -w
 
 # Get external IP
-$API_IP = kubectl get svc rust-api-mq -n hello-apis -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+$API_IP = kubectl get svc rust-hello-api -n hello-apis -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
 Write-Host "API URL: http://$API_IP"
 
 # Test basic connectivity
@@ -1204,20 +1204,20 @@ kubectl exec -it rabbitmq-0 -n hello-apis -- rabbitmqctl list_queues name consum
 
 ```powershell
 # Check API logs
-kubectl logs -l app=rust-api-mq -n hello-apis --tail=100
+kubectl logs -l app=rust-hello-api -n hello-apis --tail=100
 
 # Verify API can reach RabbitMQ
 kubectl exec -it <rust-api-pod> -n hello-apis -- /bin/sh
 # (inside pod) nc -zv rabbitmq 5672
 
 # Check environment variables
-kubectl describe pod -l app=rust-api-mq -n hello-apis | Select-String -Pattern "RABBITMQ"
+kubectl describe pod -l app=rust-hello-api -n hello-apis | Select-String -Pattern "RABBITMQ"
 
 # Test RabbitMQ credentials
 kubectl exec -it rabbitmq-0 -n hello-apis -- rabbitmqctl authenticate_user admin admin123
 
 # Restart API pods
-kubectl rollout restart deployment rust-api-mq -n hello-apis
+kubectl rollout restart deployment rust-hello-api -n hello-apis
 ```
 
 #### High CPU but No Scaling
@@ -1322,7 +1322,7 @@ docker-compose down --remove-orphans
 # Delete Lab 2 resources only
 kubectl delete -f src/k8s/worker-hpa.yaml
 kubectl delete -f src/k8s/worker-deployment.yaml
-kubectl delete -f src/k8s/rust-api-mq-deployment.yaml
+kubectl delete -f src/k8s/rust-deployment.yaml
 kubectl delete -f src/k8s/rabbitmq-deployment.yaml
 
 # Delete secrets

--- a/Labs/Lab3.Devcontainer.md
+++ b/Labs/Lab3.Devcontainer.md
@@ -16,8 +16,28 @@ This lab covers:
 This lab demonstrates modern cloud-native development practices including containerized development
 environments, dual-mode workflows, and seamless progression from local development to production deployment.
 
+## Lab Version
+
+This lab is stabilized on the **`lab3-v1.0`** tag and the **`labs/lab3`** branch.
+
+To follow this lab against a known-good snapshot of the repository:
+
+```powershell
+git fetch --tags
+git checkout lab3-v1.0
+```
+
+To make changes while following along, create a working branch from the tag:
+
+```powershell
+git checkout -b my-lab3-work lab3-v1.0
+```
+
+For the latest in-progress version of the lab, use the `main` branch or the long-lived `labs/lab3` branch (which tracks the tip of this lab).
+
 ## Table of Contents
 
+- [Lab Version](#lab-version)
 - [Prerequisites](#prerequisites)
 - [Development Environment Architecture](#development-environment-architecture)
 - [Devcontainer Deep Dive](#devcontainer-deep-dive)

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 # Complete containerized setup - all services running in Docker
 # For infrastructure-only setup, use: docker-compose up
 # For this full setup, use: docker-compose -f docker-compose.full.yml up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 # Infrastructure-only setup for dev container workflow
 # Applications run directly in dev container for faster development iteration
 # For full containerized setup, use: docker-compose -f docker-compose.full.yml up


### PR DESCRIPTION
## Summary

Validates that each lab is still followable end-to-end, fixes one real bug in Lab 2, and adds a "Lab Version" block to each lab guide so a user can pin to an immutable snapshot before starting.

After this PR merges, three tags and three branches will be created (see *Post-merge actions* below).

## Validation performed

Static checks only (no Azure deploy):

| Check | Result |
|---|---|
| `az bicep build src/infra/main.bicep` | ✅ Builds clean |
| `kubectl apply --dry-run=client` on all 10 `src/k8s/**/*.yaml` | ✅ All pass |
| `docker compose config` on 3 compose files | ✅ Clean (after the warning fix in this PR) |
| `.devcontainer/devcontainer.json` schema + 9 referenced scripts | ✅ All present (already validated in PR #37/#38) |
| Internal file/path references in each lab MD | ✅ All resolve (1 broken ref fixed in this PR) |

## Commits (Conventional Commits)

### 1. `docs(labs): fix stale k8s names in Lab 2 (rust-hello-api)`
Lab 2 referenced `src/k8s/rust-api-mq-deployment.yaml` (does not exist — never has) and used label/service name `rust-api-mq` in 9 places. The actual file is `src/k8s/rust-deployment.yaml` and the deployment defines `app: rust-hello-api`. Without this fix every `kubectl ... -l app=rust-api-mq` and `kubectl ... svc rust-api-mq` returns "no resources found", making the AKS deployment section unfollowable.

### 2. `chore(compose): drop obsolete top-level `version` key`
Removes the deprecated `version: "3.8"` from the three compose files. Compose v2 ignores it and warns on every invocation.

### 3. `docs(labs): add 'Lab Version' section with checkout instructions`
Each lab gets a section near the top:

> ## Lab Version
> This lab is stabilized on the **`labN-v1.0`** tag and the **`labs/labN`** branch.
> 
> `git fetch --tags && git checkout labN-v1.0`
> 
> *(plus working-branch and main-branch alternatives)*

Table of Contents entries added accordingly.

## Post-merge actions

After this PR is merged, the merge commit will be tagged and branched:

```bash
git checkout main && git pull
MERGE_SHA=$(git rev-parse HEAD)

git tag lab1-v1.0 $MERGE_SHA
git tag lab2-v1.0 $MERGE_SHA
git tag lab3-v1.0 $MERGE_SHA
git push origin lab1-v1.0 lab2-v1.0 lab3-v1.0

git branch labs/lab1 $MERGE_SHA
git branch labs/lab2 $MERGE_SHA
git branch labs/lab3 $MERGE_SHA
git push origin labs/lab1 labs/lab2 labs/lab3
```

(I will perform this step after you merge.)

## What was *not* changed

- No live Azure / AKS deploy was performed (would burn quota and tokens are not interactive in this autopilot session). All validation is static.
- The `cat > .devcontainer/switch-mode.sh` / `pre-commit-setup.sh` heredocs in Lab 3 were left in place — they are tutorial content that creates those scripts as part of the lesson, not stale references to existing files.
- No version bumps for devcontainer features or VS Code extensions (already done in earlier PRs).