### PR TITLE
feat(docker-cleanup): add tiered Docker cleanup automation + Copilot CLI skill

### DIFF
--- a/.build/Invoke-DockerCleanup.ps1
+++ b/.build/Invoke-DockerCleanup.ps1
@@ -477,6 +477,14 @@ try {
     exit 2
 }
 
+# Guard against accidentally targeting a remote daemon via DOCKER_HOST.
+if ($Mode -ne 'Survey' -and -not [string]::IsNullOrWhiteSpace($env:DOCKER_HOST) -and $env:DOCKER_HOST -match '^(?i)tcp://') {
+    Write-Log "DOCKER_HOST is set to '$($env:DOCKER_HOST)'; this script can prune remote resources." -Level WARN
+    if (-not (Confirm-Or-Exit "Proceed while DOCKER_HOST targets a remote engine")) {
+        Write-Log "User declined due to remote DOCKER_HOST; exiting." -Level WARN
+        exit 0
+    }
+}
 # 2. Survey (always run)
 Write-Log "--- Survey ---"
 $before = Get-DockerSurvey

--- a/.build/Invoke-DockerCleanup.ps1
+++ b/.build/Invoke-DockerCleanup.ps1
@@ -281,14 +281,11 @@ function Get-ProtectedImageIds {
         $kctx = $null
 
         try {
-
             $kctx = & kubectl config current-context 2>$null
-
         } catch {
-
             Write-Log "kubectl not available; skipping Kubernetes image protection." -Level DEBUG
-
         }
+    }
 
 
 
@@ -382,7 +379,7 @@ function Remove-StaleContainers {
             $removed++
             $out | ForEach-Object { Write-Log "  $_" -Level DEBUG }
         } else {
-            Write-Log "  could not remove container $id: $out" -Level WARN
+            Write-Log "  could not remove container ($id): $out" -Level WARN
         }
     }
     return $removed
@@ -477,14 +474,22 @@ try {
     exit 2
 }
 
-# Guard against accidentally targeting a remote daemon via DOCKER_HOST.
-if ($Mode -ne 'Survey' -and -not [string]::IsNullOrWhiteSpace($env:DOCKER_HOST) -and $env:DOCKER_HOST -match '^(?i)tcp://') {
-    Write-Log "DOCKER_HOST is set to '$($env:DOCKER_HOST)'; this script can prune remote resources." -Level WARN
-    if (-not (Confirm-Or-Exit "Proceed while DOCKER_HOST targets a remote engine")) {
-        Write-Log "User declined due to remote DOCKER_HOST; exiting." -Level WARN
-        exit 0
-    }
-}
+# Guard against accidentally targeting a remote daemon via DOCKER_HOST.
+
+if ($Mode -ne 'Survey' -and -not [string]::IsNullOrWhiteSpace($env:DOCKER_HOST) -and $env:DOCKER_HOST -match '^(?i)tcp://') {
+
+    Write-Log "DOCKER_HOST is set to '$($env:DOCKER_HOST)'; this script can prune remote resources." -Level WARN
+
+    if (-not (Confirm-Or-Exit "Proceed while DOCKER_HOST targets a remote engine")) {
+
+        Write-Log "User declined due to remote DOCKER_HOST; exiting." -Level WARN
+
+        exit 0
+
+    }
+
+}
+
 # 2. Survey (always run)
 Write-Log "--- Survey ---"
 $before = Get-DockerSurvey
@@ -526,14 +531,14 @@ $summary.BytesFreedImages += Invoke-DockerPrune -Resource 'network'
 
 if ($Mode -eq 'Safe') {
     $r = Remove-Images-Unused -ProtectedIds $protected.Ids -Reasons $protected.Reasons
-    $summary.ImagesRemoved   += $r.Count
+    $summary.ImagesRemoved += $r.Count
     $summary.BytesFreedImages += $r.BytesFreed
 }
 
 if ($Mode -in 'Standard', 'Aggressive') {
     $includeAll = ($Mode -eq 'Aggressive')
     $r = Remove-Images-Unused -ProtectedIds $protected.Ids -Reasons $protected.Reasons -IncludeAll:$includeAll
-    $summary.ImagesRemoved   += $r.Count
+    $summary.ImagesRemoved += $r.Count
     $summary.BytesFreedImages += $r.BytesFreed
 
     if ($IncludeBuildCache) {
@@ -546,13 +551,10 @@ if ($Mode -eq 'Aggressive' -or ($Mode -eq 'Standard' -and $IncludeVolumes)) {
 }
 
 # 6. Final survey + summary
-Write-Log "  Stale containers $verb: $($summary.StaleContainersRemoved)"
-Write-Log "  Images $verb:           $($summary.ImagesRemoved)"
+Write-Log "  Stale containers ($verb): $($summary.StaleContainersRemoved)"
+Write-Log "  Images ($verb):           $($summary.ImagesRemoved)"
 foreach ($k in $after.Keys) {
     $v = $after[$k]
-
-Write-Log "  Images $verb:           $($summary.ImagesRemoved)"
-
     Write-Log ("  {0,-14} total={1,4} active={2,4} size={3,-10} reclaimable={4}" -f $k, $v.Total, $v.Active, $v.Size, $v.Reclaimable)
 }
 

--- a/.build/Invoke-DockerCleanup.ps1
+++ b/.build/Invoke-DockerCleanup.ps1
@@ -278,13 +278,20 @@ function Get-ProtectedImageIds {
                 Add-ProtectedId $id "devcontainer base for active vsc-* image '$name'"
             }
         }
-        $kctx = $null
-        try {
-            $kctx = & kubectl config current-context 2>$null
-        } catch {
-            Write-Log "kubectl not available; skipping Kubernetes image protection." -Level DEBUG
-        }
-
+        $kctx = $null
+
+        try {
+
+            $kctx = & kubectl config current-context 2>$null
+
+        } catch {
+
+            Write-Log "kubectl not available; skipping Kubernetes image protection." -Level DEBUG
+
+        }
+
+
+
 
     # 4. Docker Desktop Kubernetes images (when current context = docker-desktop)
     if (-not $SkipKubectlProtection) {
@@ -531,9 +538,6 @@ if ($Mode -eq 'Aggressive' -or ($Mode -eq 'Standard' -and $IncludeVolumes)) {
 }
 
 # 6. Final survey + summary
-Write-Log "--- Post-cleanup survey ---"
-$after = Get-DockerSurvey
-$verb = if ($DryRun) { 'planned' } else { 'removed' }
 Write-Log "  Stale containers $verb: $($summary.StaleContainersRemoved)"
 Write-Log "  Images $verb:           $($summary.ImagesRemoved)"
 foreach ($k in $after.Keys) {

--- a/.build/Invoke-DockerCleanup.ps1
+++ b/.build/Invoke-DockerCleanup.ps1
@@ -406,6 +406,10 @@ function Remove-Images-Unused {
         }
         $candidates += [pscustomobject]@{ Id = $id; Name = $name; Size = $size; Age = $age }
     }
+    }
+
+    # De-dupe by image ID: a single image may have multiple tags/rows in `docker images`.
+    $candidates = $candidates | Sort-Object -Property Id -Unique
 
     if ($candidates.Count -eq 0) {
         Write-Log "No unused images to remove."
@@ -478,16 +482,26 @@ if ($Mode -ne 'Survey' -and -not [string]::IsNullOrWhiteSpace($env:DOCKER_HOST) 
 
     Write-Log "DOCKER_HOST is set to '$($env:DOCKER_HOST)'; this script can prune remote resources." -Level WARN
 
-    # Never allow -Force to bypass the remote-engine guard. DryRun is still OK.
-    $origForce = $Force
-    $Force = $false
-    try {
-        if (-not (Confirm-Or-Exit "Proceed while DOCKER_HOST targets a remote engine")) {
-            Write-Log "User declined due to remote DOCKER_HOST; exiting." -Level WARN
-            exit 0
-        }
-    } finally {
-        $Force = $origForce
+    # Never allow -Force to bypass the remote-engine guard. DryRun is still OK.
+
+    $origForce = $Force
+
+    $Force = $false
+
+    try {
+
+        if (-not (Confirm-Or-Exit "Proceed while DOCKER_HOST targets a remote engine")) {
+
+            Write-Log "User declined due to remote DOCKER_HOST; exiting." -Level WARN
+
+            exit 0
+
+        }
+
+    } finally {
+
+        $Force = $origForce
+
     }
 
 }

--- a/.build/Invoke-DockerCleanup.ps1
+++ b/.build/Invoke-DockerCleanup.ps1
@@ -9,8 +9,9 @@
     tiers (Safe / Standard / Aggressive) plus a default Survey-only mode.
 
     Auto-protects:
-      - Images used by any running container
+      - Images bound to any container (running or stopped)
       - Images referenced by docker-compose*.yml files under -RepoPath
+      - mcr.microsoft.com/devcontainers/* base images when any vsc-* devcontainer image is present
       - Docker Desktop Kubernetes images when current kubectl context is
         'docker-desktop' (override with -SkipKubectlProtection)
       - Anything matching -IgnoreImage (regex array)
@@ -150,9 +151,10 @@ function Invoke-Docker {
 function ConvertFrom-DockerSize {
     param([string] $Size)
     if ([string]::IsNullOrWhiteSpace($Size)) { return 0L }
-    if ($Size -match '^\s*([\d\.]+)\s*([KMGT]?B)?\s*$') {
+    if ($Size -match '^\s*([\d\.]+)\s*([kKmMgGtT]?B)?\s*$') {
         $n = [double]$Matches[1]
-        switch ($Matches[2]) {
+        $unit = if ($Matches[2]) { $Matches[2].ToUpperInvariant() } else { '' }
+        switch ($unit) {
             'KB' { return [long]($n * 1KB) }
             'MB' { return [long]($n * 1MB) }
             'GB' { return [long]($n * 1GB) }
@@ -347,9 +349,17 @@ function Remove-StaleContainers {
     Write-Log "Removing $($Stale.Count) stale container(s) older than $MaxAgeDays days:"
     $Stale | ForEach-Object { Write-Log "  - $($_.Name) [$($_.Image)] $($_.Status)" }
     if ($DryRun) { Write-Log "  [DryRun] skipped removal"; return $Stale.Count }
-    $ids = @($Stale | ForEach-Object { $_.Id })
-    & docker rm @ids 2>&1 | ForEach-Object { Write-Log "  $_" }
-    return $Stale.Count
+    $removed = 0
+    foreach ($id in ($Stale | ForEach-Object { $_.Id })) {
+        $out = & docker rm $id 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            $removed++
+            $out | ForEach-Object { Write-Log "  $_" -Level DEBUG }
+        } else {
+            Write-Log "  could not remove container $id: $out" -Level WARN
+        }
+    }
+    return $removed
 }
 
 function Remove-Images-Unused {
@@ -389,16 +399,18 @@ function Remove-Images-Unused {
     if ($DryRun) { Write-Log "  [DryRun] skipped removal"; return @{ Count = $candidates.Count; BytesFreed = 0L } }
 
     $removed = 0
+    $bytesFreed = 0L
     foreach ($c in $candidates) {
         $out = & docker rmi $c.Id 2>&1
         if ($LASTEXITCODE -eq 0) {
             $removed++
+            $bytesFreed += ConvertFrom-DockerSize $c.Size
             Write-Log "  removed $($c.Id)  $($c.Name)"
         } else {
             Write-Log "  could not remove $($c.Id)  $($c.Name): $out" -Level WARN
         }
     }
-    return @{ Count = $removed; BytesFreed = $totalBytes }
+    return @{ Count = $removed; BytesFreed = $bytesFreed }
 }
 
 function Invoke-DockerPrune {
@@ -478,7 +490,7 @@ $summary.StaleContainersRemoved = Remove-StaleContainers -Stale $stale
 # Unused networks (always safe — only removes those with no attached containers)
 $summary.BytesFreedImages += Invoke-DockerPrune -Resource 'network'
 
-if ($Mode -in 'Safe') {
+if ($Mode -eq 'Safe') {
     $r = Remove-Images-Unused -ProtectedIds $protected.Ids -Reasons $protected.Reasons
     $summary.ImagesRemoved   += $r.Count
     $summary.BytesFreedImages += $r.BytesFreed
@@ -511,7 +523,7 @@ Write-Log "================================================================"
 Write-Log "RUN SUMMARY"
 Write-Log "  Stale containers removed: $($summary.StaleContainersRemoved)"
 Write-Log "  Images removed:           $($summary.ImagesRemoved)"
-Write-Log "  Bytes freed (images):     $(Format-Bytes $summary.BytesFreedImages)"
+Write-Log "  Bytes freed (images+networks): $(Format-Bytes $summary.BytesFreedImages)"
 Write-Log "  Bytes freed (cache):      $(Format-Bytes $summary.BytesFreedCache)"
 Write-Log "  Bytes freed (volumes):    $(Format-Bytes $summary.BytesFreedVolumes)"
 $total = $summary.BytesFreedImages + $summary.BytesFreedCache + $summary.BytesFreedVolumes

--- a/.build/Invoke-DockerCleanup.ps1
+++ b/.build/Invoke-DockerCleanup.ps1
@@ -23,10 +23,10 @@
     Survey      Report only, make no changes (default).
     Safe        Remove exited containers older than -MaxAgeDays, dangling
                 images, and unused networks. Volumes and build cache untouched.
-    Standard    Safe + remove dangling/untagged (<none>) images + prune build cache.
+    Standard    Safe + remove dangling/untagged (<none>) images + prune build cache.
                 Volumes still untouched unless -IncludeVolumes.
-    Aggressive  Standard + remove ALL unused images (including named) + prune
-                unused volumes (regardless of -IncludeVolumes).
+    Aggressive  Standard + remove ALL unused images (including named) + prune
+                unused volumes (regardless of -IncludeVolumes).
 
 .PARAMETER DryRun
     Print every planned action without executing it. Implies non-destructive.
@@ -303,10 +303,10 @@ function Get-ProtectedImageIds {
     if ($IgnoreImage.Count -gt 0) {
         $allImages = Invoke-Docker images --format '{{.ID}}|{{.Repository}}:{{.Tag}}'
         foreach ($row in $allImages) {
-            if ([string]::IsNullOrWhiteSpace($row)) { continue }
+            if ([string]::IsNullOrWhiteSpace($row)) { continue }
             $parts = $row -split '\|'
-            $id = $parts[0]; $name = $parts[1]
-            foreach ($p in $IgnoreImage) {
+            $id = $parts[0]; $name = $parts[1]
+            foreach ($p in $IgnoreImage) {
                 try {
                     if ($name -match $p -or $id -match $p) {
                         Add-ProtectedId $id "user ignore pattern '$p'"
@@ -521,11 +521,11 @@ if ($Mode -eq 'Aggressive' -or ($Mode -eq 'Standard' -and $IncludeVolumes)) {
 # 6. Final survey + summary
 Write-Log "--- Post-cleanup survey ---"
 $after = Get-DockerSurvey
-$verb = if ($DryRun) { 'planned' } else { 'removed' }
-Write-Log "  Stale containers $verb: $($summary.StaleContainersRemoved)"
-Write-Log "  Images $verb:           $($summary.ImagesRemoved)"
-foreach ($k in $after.Keys) {
-    $v = $after[$k]
+$verb = if ($DryRun) { 'planned' } else { 'removed' }
+Write-Log "  Stale containers $verb: $($summary.StaleContainersRemoved)"
+Write-Log "  Images $verb:           $($summary.ImagesRemoved)"
+foreach ($k in $after.Keys) {
+    $v = $after[$k]
 
 Write-Log "  Images $verb:           $($summary.ImagesRemoved)"
 

--- a/.build/Invoke-DockerCleanup.ps1
+++ b/.build/Invoke-DockerCleanup.ps1
@@ -35,8 +35,10 @@
     Skip the confirmation prompt before destructive operations.
 
 .PARAMETER MaxAgeDays
-    Containers older than this many days are eligible for removal (when in exited / dead / created state).
-    Default 30.
+    Containers older than this many days are eligible for removal (when in exited / dead / created state).
+
+    Default 30.
+
 
 .PARAMETER IncludeVolumes
     Allow Standard mode to prune unused named volumes. Aggressive always
@@ -302,9 +304,13 @@ function Get-ProtectedImageIds {
         $allImages = Invoke-Docker images --format '{{.ID}}|{{.Repository}}:{{.Tag}}'
         foreach ($row in $allImages) {
             $parts = $row -split '\|'
-            $id = $parts[0]; $name = $parts[1]
-            foreach ($p in $IgnoreImage) {
-                if ($name -match $p -or $id -match $p) {
+                try {
+                    if ($name -match $p -or $id -match $p) {
+                        Add-ProtectedId $id "user ignore pattern '$p'"
+                        break
+                    }
+                } catch {
+                    Write-Log "IgnoreImage pattern '$p' is not a valid regex; skipping" -Level WARN
                     Add-ProtectedId $id "user ignore pattern '$p'"
                     break
                 }

--- a/.build/Invoke-DockerCleanup.ps1
+++ b/.build/Invoke-DockerCleanup.ps1
@@ -23,10 +23,10 @@
     Survey      Report only, make no changes (default).
     Safe        Remove exited containers older than -MaxAgeDays, dangling
                 images, and unused networks. Volumes and build cache untouched.
-    Standard    Safe + remove unreferenced images + prune build cache.
+    Standard    Safe + remove dangling/untagged (<none>) images + prune build cache.
                 Volumes still untouched unless -IncludeVolumes.
-    Aggressive  Standard + remove ALL unused images (Docker prune --all)
-                + prune unused volumes (regardless of -IncludeVolumes).
+    Aggressive  Standard + remove ALL unused images (including named) + prune
+                unused volumes (regardless of -IncludeVolumes).
 
 .PARAMETER DryRun
     Print every planned action without executing it. Implies non-destructive.
@@ -303,23 +303,17 @@ function Get-ProtectedImageIds {
     if ($IgnoreImage.Count -gt 0) {
         $allImages = Invoke-Docker images --format '{{.ID}}|{{.Repository}}:{{.Tag}}'
         foreach ($row in $allImages) {
+            if ([string]::IsNullOrWhiteSpace($row)) { continue }
             $parts = $row -split '\|'
+            $id = $parts[0]; $name = $parts[1]
+            foreach ($p in $IgnoreImage) {
                 try {
-
                     if ($name -match $p -or $id -match $p) {
-
                         Add-ProtectedId $id "user ignore pattern '$p'"
-
                         break
-
                     }
-
                 } catch {
-
                     Write-Log "IgnoreImage pattern '$p' is not a valid regex; skipping" -Level WARN
-
-                    Add-ProtectedId $id "user ignore pattern '$p'"
-                    break
                 }
             }
         }
@@ -530,6 +524,11 @@ $after = Get-DockerSurvey
 $verb = if ($DryRun) { 'planned' } else { 'removed' }
 Write-Log "  Stale containers $verb: $($summary.StaleContainersRemoved)"
 Write-Log "  Images $verb:           $($summary.ImagesRemoved)"
+foreach ($k in $after.Keys) {
+    $v = $after[$k]
+
+Write-Log "  Images $verb:           $($summary.ImagesRemoved)"
+
     Write-Log ("  {0,-14} total={1,4} active={2,4} size={3,-10} reclaimable={4}" -f $k, $v.Total, $v.Active, $v.Size, $v.Reclaimable)
 }
 

--- a/.build/Invoke-DockerCleanup.ps1
+++ b/.build/Invoke-DockerCleanup.ps1
@@ -143,11 +143,15 @@ Rotate-Log
 
 function Invoke-Docker {
     param([Parameter(Mandatory, ValueFromRemainingArguments)][string[]] $DockerArgs)
-
-    # Force array output so callers can safely foreach even when docker returns a single line.
-    $out = @(& docker @DockerArgs 2>&1)
+
+
+    # Force array output so callers can safely foreach even when docker returns a single line.
+
+    $out = @(& docker @DockerArgs 2>&1)
+
     if ($LASTEXITCODE -ne 0) {
-        throw "docker $($DockerArgs -join ' ') failed: $($out -join [Environment]::NewLine)"
+        throw "docker $($DockerArgs -join ' ') failed: $($out -join [Environment]::NewLine)"
+
     }
     return $out
 }
@@ -274,7 +278,13 @@ function Get-ProtectedImageIds {
                 Add-ProtectedId $id "devcontainer base for active vsc-* image '$name'"
             }
         }
-    }
+        $kctx = $null
+        try {
+            $kctx = & kubectl config current-context 2>$null
+        } catch {
+            Write-Log "kubectl not available; skipping Kubernetes image protection." -Level DEBUG
+        }
+
 
     # 4. Docker Desktop Kubernetes images (when current context = docker-desktop)
     if (-not $SkipKubectlProtection) {

--- a/.build/Invoke-DockerCleanup.ps1
+++ b/.build/Invoke-DockerCleanup.ps1
@@ -143,9 +143,11 @@ Rotate-Log
 
 function Invoke-Docker {
     param([Parameter(Mandatory, ValueFromRemainingArguments)][string[]] $DockerArgs)
-    $out = & docker @DockerArgs 2>&1
+
+    # Force array output so callers can safely foreach even when docker returns a single line.
+    $out = @(& docker @DockerArgs 2>&1)
     if ($LASTEXITCODE -ne 0) {
-        throw "docker $($DockerArgs -join ' ') failed: $out"
+        throw "docker $($DockerArgs -join ' ') failed: $($out -join [Environment]::NewLine)"
     }
     return $out
 }

--- a/.build/Invoke-DockerCleanup.ps1
+++ b/.build/Invoke-DockerCleanup.ps1
@@ -478,12 +478,16 @@ if ($Mode -ne 'Survey' -and -not [string]::IsNullOrWhiteSpace($env:DOCKER_HOST) 
 
     Write-Log "DOCKER_HOST is set to '$($env:DOCKER_HOST)'; this script can prune remote resources." -Level WARN
 
-    if (-not (Confirm-Or-Exit "Proceed while DOCKER_HOST targets a remote engine")) {
-
-        Write-Log "User declined due to remote DOCKER_HOST; exiting." -Level WARN
-
-        exit 0
-
+    # Never allow -Force to bypass the remote-engine guard. DryRun is still OK.
+    $origForce = $Force
+    $Force = $false
+    try {
+        if (-not (Confirm-Or-Exit "Proceed while DOCKER_HOST targets a remote engine")) {
+            Write-Log "User declined due to remote DOCKER_HOST; exiting." -Level WARN
+            exit 0
+        }
+    } finally {
+        $Force = $origForce
     }
 
 }

--- a/.build/Invoke-DockerCleanup.ps1
+++ b/.build/Invoke-DockerCleanup.ps1
@@ -286,11 +286,11 @@ function Get-ProtectedImageIds {
         $kctx = $null
 
         try {
-            $kctx = & kubectl config current-context 2>$null
+            $kctx = (& kubectl config current-context 2>$null).Trim()
         } catch {
             Write-Log "kubectl not available; skipping Kubernetes image protection." -Level DEBUG
+            $kctx = $null
         }
-        $kctx = & kubectl config current-context 2>$null
         if ($kctx -eq 'docker-desktop') {
             Write-Log "Kubectl context is 'docker-desktop'; auto-protecting Docker Desktop K8s images"
             $patterns = @(
@@ -377,7 +377,7 @@ function Remove-StaleContainers {
             $removed++
             $out | ForEach-Object { Write-Log "  $_" -Level DEBUG }
         } else {
-            Write-Log "  could not remove container ($id): $out" -Level WARN
+            Write-Log "  could not remove container ($id): $($out -join [Environment]::NewLine)" -Level WARN
         }
     }
     return $removed
@@ -428,7 +428,7 @@ function Remove-Images-Unused {
             $bytesFreed += ConvertFrom-DockerSize $c.Size
             Write-Log "  removed $($c.Id)  $($c.Name)"
         } else {
-            Write-Log "  could not remove $($c.Id)  $($c.Name): $out" -Level WARN
+            Write-Log "  could not remove $($c.Id)  $($c.Name): $($out -join [Environment]::NewLine)" -Level WARN
         }
     }
     return @{ Count = $removed; BytesFreed = $bytesFreed }
@@ -474,7 +474,7 @@ try {
 
 # Guard against accidentally targeting a remote daemon via DOCKER_HOST.
 
-if ($Mode -ne 'Survey' -and -not [string]::IsNullOrWhiteSpace($env:DOCKER_HOST) -and $env:DOCKER_HOST -match '^(?i)tcp://') {
+if ($Mode -ne 'Survey' -and -not [string]::IsNullOrWhiteSpace($env:DOCKER_HOST) -and $env:DOCKER_HOST -match '^(?i)(tcp|ssh)://') {
 
     Write-Log "DOCKER_HOST is set to '$($env:DOCKER_HOST)'; this script can prune remote resources." -Level WARN
 

--- a/.build/Invoke-DockerCleanup.ps1
+++ b/.build/Invoke-DockerCleanup.ps1
@@ -35,8 +35,8 @@
     Skip the confirmation prompt before destructive operations.
 
 .PARAMETER MaxAgeDays
-    Containers / images older than this many days are eligible for cleanup
-    in Safe and Standard modes. Default 30.
+    Containers older than this many days are eligible for removal (when in exited / dead / created state).
+    Default 30.
 
 .PARAMETER IncludeVolumes
     Allow Standard mode to prune unused named volumes. Aggressive always

--- a/.build/Invoke-DockerCleanup.ps1
+++ b/.build/Invoke-DockerCleanup.ps1
@@ -278,6 +278,11 @@ function Get-ProtectedImageIds {
                 Add-ProtectedId $id "devcontainer base for active vsc-* image '$name'"
             }
         }
+    }
+
+    # 4. Docker Desktop Kubernetes images (when current context = docker-desktop)
+    if (-not $SkipKubectlProtection) {
+
         $kctx = $null
 
         try {
@@ -285,13 +290,6 @@ function Get-ProtectedImageIds {
         } catch {
             Write-Log "kubectl not available; skipping Kubernetes image protection." -Level DEBUG
         }
-    }
-
-
-
-
-    # 4. Docker Desktop Kubernetes images (when current context = docker-desktop)
-    if (-not $SkipKubectlProtection) {
         $kctx = & kubectl config current-context 2>$null
         if ($kctx -eq 'docker-desktop') {
             Write-Log "Kubectl context is 'docker-desktop'; auto-protecting Docker Desktop K8s images"
@@ -551,6 +549,9 @@ if ($Mode -eq 'Aggressive' -or ($Mode -eq 'Standard' -and $IncludeVolumes)) {
 }
 
 # 6. Final survey + summary
+Write-Log "--- Final survey ---"
+$after = Get-DockerSurvey
+$verb = if ($DryRun) { 'planned' } else { 'removed' }
 Write-Log "  Stale containers ($verb): $($summary.StaleContainersRemoved)"
 Write-Log "  Images ($verb):           $($summary.ImagesRemoved)"
 foreach ($k in $after.Keys) {

--- a/.build/Invoke-DockerCleanup.ps1
+++ b/.build/Invoke-DockerCleanup.ps1
@@ -304,13 +304,20 @@ function Get-ProtectedImageIds {
         $allImages = Invoke-Docker images --format '{{.ID}}|{{.Repository}}:{{.Tag}}'
         foreach ($row in $allImages) {
             $parts = $row -split '\|'
-                try {
-                    if ($name -match $p -or $id -match $p) {
-                        Add-ProtectedId $id "user ignore pattern '$p'"
-                        break
-                    }
-                } catch {
-                    Write-Log "IgnoreImage pattern '$p' is not a valid regex; skipping" -Level WARN
+                try {
+
+                    if ($name -match $p -or $id -match $p) {
+
+                        Add-ProtectedId $id "user ignore pattern '$p'"
+
+                        break
+
+                    }
+
+                } catch {
+
+                    Write-Log "IgnoreImage pattern '$p' is not a valid regex; skipping" -Level WARN
+
                     Add-ProtectedId $id "user ignore pattern '$p'"
                     break
                 }
@@ -520,8 +527,9 @@ if ($Mode -eq 'Aggressive' -or ($Mode -eq 'Standard' -and $IncludeVolumes)) {
 # 6. Final survey + summary
 Write-Log "--- Post-cleanup survey ---"
 $after = Get-DockerSurvey
-foreach ($k in $after.Keys) {
-    $v = $after[$k]
+$verb = if ($DryRun) { 'planned' } else { 'removed' }
+Write-Log "  Stale containers $verb: $($summary.StaleContainersRemoved)"
+Write-Log "  Images $verb:           $($summary.ImagesRemoved)"
     Write-Log ("  {0,-14} total={1,4} active={2,4} size={3,-10} reclaimable={4}" -f $k, $v.Total, $v.Active, $v.Size, $v.Reclaimable)
 }
 

--- a/.build/Invoke-DockerCleanup.ps1
+++ b/.build/Invoke-DockerCleanup.ps1
@@ -1,0 +1,521 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    Tiered, safety-first cleanup of local Docker containers, images, volumes,
+    networks, and build cache.
+
+.DESCRIPTION
+    Surveys Docker disk usage and removes stale resources in three escalating
+    tiers (Safe / Standard / Aggressive) plus a default Survey-only mode.
+
+    Auto-protects:
+      - Images used by any running container
+      - Images referenced by docker-compose*.yml files under -RepoPath
+      - Docker Desktop Kubernetes images when current kubectl context is
+        'docker-desktop' (override with -SkipKubectlProtection)
+      - Anything matching -IgnoreImage (regex array)
+
+    All actions are logged to docker_cleanup.log next to this script (rotated
+    at ~5 MB, 5 backups).
+
+.PARAMETER Mode
+    Survey      Report only, make no changes (default).
+    Safe        Remove exited containers older than -MaxAgeDays, dangling
+                images, and unused networks. Volumes and build cache untouched.
+    Standard    Safe + remove unreferenced images + prune build cache.
+                Volumes still untouched unless -IncludeVolumes.
+    Aggressive  Standard + remove ALL unused images (Docker prune --all)
+                + prune unused volumes (regardless of -IncludeVolumes).
+
+.PARAMETER DryRun
+    Print every planned action without executing it. Implies non-destructive.
+
+.PARAMETER Force
+    Skip the confirmation prompt before destructive operations.
+
+.PARAMETER MaxAgeDays
+    Containers / images older than this many days are eligible for cleanup
+    in Safe and Standard modes. Default 30.
+
+.PARAMETER IncludeVolumes
+    Allow Standard mode to prune unused named volumes. Aggressive always
+    includes volumes regardless of this flag.
+
+.PARAMETER IncludeBuildCache
+    Prune build cache in Standard / Aggressive modes. Default $true.
+
+.PARAMETER RepoPath
+    One or more paths containing docker-compose*.yml files whose image
+    references will be auto-protected. Pass repos you actively work on.
+
+.PARAMETER IgnoreImage
+    Array of regex patterns. Any image whose 'repo:tag' or short ID matches
+    is protected from removal in all modes.
+
+.PARAMETER SkipKubectlProtection
+    Don't auto-protect Docker Desktop K8s images even if the current kubectl
+    context is 'docker-desktop'.
+
+.EXAMPLE
+    .\Invoke-DockerCleanup.ps1
+    Survey only — no changes.
+
+.EXAMPLE
+    .\Invoke-DockerCleanup.ps1 -Mode Standard -RepoPath E:\Code\RustAksDemoLab
+    Recommended cleanup. Protects images referenced by the lab's compose files.
+
+.EXAMPLE
+    .\Invoke-DockerCleanup.ps1 -Mode Aggressive -IncludeVolumes -Force
+    Maximum cleanup, unattended.
+
+.NOTES
+    Author: Nick Hara (with GitHub Copilot CLI)
+    Requires: Docker Desktop / Docker Engine reachable via 'docker' on PATH.
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('Survey', 'Safe', 'Standard', 'Aggressive')]
+    [string] $Mode = 'Survey',
+
+    [switch] $DryRun,
+    [switch] $Force,
+
+    [int] $MaxAgeDays = 30,
+
+    [switch] $IncludeVolumes,
+    [bool]   $IncludeBuildCache = $true,
+
+    [string[]] $RepoPath = @(),
+    [string[]] $IgnoreImage = @(),
+
+    [switch] $SkipKubectlProtection
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+$script:LogFile = Join-Path $PSScriptRoot 'docker_cleanup.log'
+$script:LogMaxBytes = 5 * 1024 * 1024
+$script:LogBackupCount = 5
+
+function Rotate-Log {
+    if (-not (Test-Path $script:LogFile)) { return }
+    $size = (Get-Item $script:LogFile).Length
+    if ($size -lt $script:LogMaxBytes) { return }
+
+    for ($i = $script:LogBackupCount - 1; $i -ge 1; $i--) {
+        $src = "$($script:LogFile).$i"
+        $dst = "$($script:LogFile).$($i + 1)"
+        if (Test-Path $src) { Move-Item $src $dst -Force }
+    }
+    Move-Item $script:LogFile "$($script:LogFile).1" -Force
+}
+
+function Write-Log {
+    param(
+        [Parameter(Mandatory)][string] $Message,
+        [ValidateSet('INFO', 'WARN', 'ERROR', 'DEBUG')]
+        [string] $Level = 'INFO'
+    )
+    $ts = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
+    $line = "$ts [$Level] $Message"
+    Add-Content -Path $script:LogFile -Value $line
+    switch ($Level) {
+        'WARN'  { Write-Host $line -ForegroundColor Yellow }
+        'ERROR' { Write-Host $line -ForegroundColor Red }
+        'DEBUG' { Write-Verbose $line }
+        default { Write-Host $line }
+    }
+}
+
+Rotate-Log
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+function Invoke-Docker {
+    param([Parameter(Mandatory, ValueFromRemainingArguments)][string[]] $DockerArgs)
+    $out = & docker @DockerArgs 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "docker $($DockerArgs -join ' ') failed: $out"
+    }
+    return $out
+}
+
+function ConvertFrom-DockerSize {
+    param([string] $Size)
+    if ([string]::IsNullOrWhiteSpace($Size)) { return 0L }
+    if ($Size -match '^\s*([\d\.]+)\s*([KMGT]?B)?\s*$') {
+        $n = [double]$Matches[1]
+        switch ($Matches[2]) {
+            'KB' { return [long]($n * 1KB) }
+            'MB' { return [long]($n * 1MB) }
+            'GB' { return [long]($n * 1GB) }
+            'TB' { return [long]($n * 1TB) }
+            default { return [long]$n }
+        }
+    }
+    return 0L
+}
+
+function Format-Bytes {
+    param([long] $Bytes)
+    if ($Bytes -ge 1GB) { return "{0:N2} GB" -f ($Bytes / 1GB) }
+    if ($Bytes -ge 1MB) { return "{0:N1} MB" -f ($Bytes / 1MB) }
+    if ($Bytes -ge 1KB) { return "{0:N0} KB" -f ($Bytes / 1KB) }
+    return "$Bytes B"
+}
+
+function Confirm-Or-Exit {
+    param([string] $Prompt)
+    if ($DryRun -or $Force) { return $true }
+    $answer = Read-Host "$Prompt [y/N]"
+    return $answer -match '^(?i)y(es)?$'
+}
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+function Get-DockerSurvey {
+    Write-Log "Gathering docker system df..."
+    $df = Invoke-Docker system df --format '{{.Type}}|{{.TotalCount}}|{{.Active}}|{{.Size}}|{{.Reclaimable}}'
+
+    $survey = [ordered]@{}
+    foreach ($row in $df) {
+        $parts = $row -split '\|'
+        if ($parts.Count -ge 5) {
+            $survey[$parts[0]] = @{
+                Total       = [int]$parts[1]
+                Active      = [int]$parts[2]
+                Size        = $parts[3]
+                Reclaimable = $parts[4]
+            }
+        }
+    }
+    return $survey
+}
+
+function Get-ProtectedImageIds {
+    $protectedIds = New-Object System.Collections.Generic.HashSet[string]
+    $reasons = @{}
+
+    function Add-ProtectedId($id, $reason) {
+        if ([string]::IsNullOrWhiteSpace($id)) { return }
+        $short = $id.Substring(0, [Math]::Min(12, $id.Length))
+        [void] $protectedIds.Add($short)
+        if (-not $reasons.ContainsKey($short)) { $reasons[$short] = @() }
+        $reasons[$short] += $reason
+    }
+
+    # 1. Images used by any container (running or not)
+    $rows = Invoke-Docker ps -a --format '{{.ID}}|{{.Image}}|{{.Status}}'
+    foreach ($r in $rows) {
+        if ([string]::IsNullOrWhiteSpace($r)) { continue }
+        $parts = $r -split '\|'
+        $cid = $parts[0]; $img = $parts[1]; $status = $parts[2]
+        $imgId = & docker inspect --format '{{.Image}}' $cid 2>$null
+        if ($imgId) {
+            $imgId = $imgId -replace '^sha256:', ''
+            $tag = if ($status -like 'Up *') { "running container '$cid' ($img)" } else { "stopped container '$cid' ($img)" }
+            Add-ProtectedId $imgId $tag
+        }
+    }
+
+    # 2. Images referenced by docker-compose*.yml in user-provided repos
+    foreach ($repo in $RepoPath) {
+        if (-not (Test-Path $repo)) {
+            Write-Log "RepoPath '$repo' does not exist, skipping" -Level WARN
+            continue
+        }
+        $composeFiles = Get-ChildItem $repo -Recurse -File -Include 'docker-compose*.yml', 'docker-compose*.yaml', 'compose*.yml', 'compose*.yaml' -ErrorAction SilentlyContinue
+        foreach ($f in $composeFiles) {
+            $content = Get-Content $f.FullName -Raw
+            # naive 'image: foo:tag' extraction; good enough for protection
+            $imgMatches = [regex]::Matches($content, '(?im)^\s*image:\s*[''"]?([^\s''"#]+)')
+            foreach ($m in $imgMatches) {
+                $ref = $m.Groups[1].Value
+                # resolve repo:tag -> image id via docker
+                $resolved = & docker image inspect --format '{{.Id}}' $ref 2>$null
+                if ($resolved) {
+                    $id = $resolved -replace '^sha256:', ''
+                    Add-ProtectedId $id "compose ref '$ref' in $($f.FullName)"
+                }
+            }
+        }
+    }
+
+    # 3. Devcontainer base images: when any vsc-* image is in use, protect
+    #    mcr.microsoft.com/devcontainers/* (the FROM lineage isn't visible to
+    #    docker inspect, so we can't walk the parent chain reliably).
+    $vscInUse = $false
+    $allImageRefs = Invoke-Docker images --format '{{.Repository}}:{{.Tag}}'
+    foreach ($img in $allImageRefs) {
+        if ($img -like 'vsc-*') { $vscInUse = $true; break }
+    }
+    if ($vscInUse) {
+        Write-Log "Detected vsc-* devcontainer image(s); auto-protecting mcr.microsoft.com/devcontainers/* bases"
+        $allImages = Invoke-Docker images --format '{{.ID}}|{{.Repository}}:{{.Tag}}'
+        foreach ($row in $allImages) {
+            $parts = $row -split '\|'
+            $id = $parts[0]; $name = $parts[1]
+            if ($name -match '^mcr\.microsoft\.com/devcontainers/') {
+                Add-ProtectedId $id "devcontainer base for active vsc-* image '$name'"
+            }
+        }
+    }
+
+    # 4. Docker Desktop Kubernetes images (when current context = docker-desktop)
+    if (-not $SkipKubectlProtection) {
+        $kctx = & kubectl config current-context 2>$null
+        if ($kctx -eq 'docker-desktop') {
+            Write-Log "Kubectl context is 'docker-desktop'; auto-protecting Docker Desktop K8s images"
+            $patterns = @(
+                '^registry\.k8s\.io/',
+                '^docker/desktop-',
+                '^kindest/node',
+                '^envoyproxy/envoy'
+            )
+            $allImages = Invoke-Docker images --format '{{.ID}}|{{.Repository}}:{{.Tag}}'
+            foreach ($row in $allImages) {
+                $parts = $row -split '\|'
+                $id = $parts[0]; $name = $parts[1]
+                foreach ($p in $patterns) {
+                    if ($name -match $p) {
+                        Add-ProtectedId $id "docker-desktop K8s image '$name'"
+                        break
+                    }
+                }
+            }
+        }
+    }
+
+    # 5. User-supplied ignore patterns
+    if ($IgnoreImage.Count -gt 0) {
+        $allImages = Invoke-Docker images --format '{{.ID}}|{{.Repository}}:{{.Tag}}'
+        foreach ($row in $allImages) {
+            $parts = $row -split '\|'
+            $id = $parts[0]; $name = $parts[1]
+            foreach ($p in $IgnoreImage) {
+                if ($name -match $p -or $id -match $p) {
+                    Add-ProtectedId $id "user ignore pattern '$p'"
+                    break
+                }
+            }
+        }
+    }
+
+    return [pscustomobject]@{ Ids = $protectedIds; Reasons = $reasons }
+}
+
+function Get-StaleContainers {
+    param([int] $OlderThanDays)
+    $cutoff = (Get-Date).AddDays(-$OlderThanDays)
+    $rows = Invoke-Docker ps -a --filter 'status=exited' --filter 'status=dead' --filter 'status=created' `
+        --format '{{.ID}}|{{.Names}}|{{.Image}}|{{.Status}}|{{.CreatedAt}}'
+    $stale = @()
+    foreach ($r in $rows) {
+        if ([string]::IsNullOrWhiteSpace($r)) { continue }
+        $parts = $r -split '\|'
+        $createdRaw = $parts[4]
+        $created = $null
+        if ([DateTime]::TryParse($createdRaw, [ref] $created)) {
+            if ($created -lt $cutoff) {
+                $stale += [pscustomobject]@{
+                    Id = $parts[0]; Name = $parts[1]; Image = $parts[2]
+                    Status = $parts[3]; Created = $created
+                }
+            }
+        }
+    }
+    return $stale
+}
+
+# ---------------------------------------------------------------------------
+# Actions
+# ---------------------------------------------------------------------------
+
+function Remove-StaleContainers {
+    param([object[]] $Stale)
+    $Stale = @($Stale | Where-Object { $_ })
+    if ($Stale.Count -eq 0) { Write-Log "No stale containers to remove."; return 0 }
+    Write-Log "Removing $($Stale.Count) stale container(s) older than $MaxAgeDays days:"
+    $Stale | ForEach-Object { Write-Log "  - $($_.Name) [$($_.Image)] $($_.Status)" }
+    if ($DryRun) { Write-Log "  [DryRun] skipped removal"; return $Stale.Count }
+    $ids = @($Stale | ForEach-Object { $_.Id })
+    & docker rm @ids 2>&1 | ForEach-Object { Write-Log "  $_" }
+    return $Stale.Count
+}
+
+function Remove-Images-Unused {
+    param(
+        [System.Collections.Generic.HashSet[string]] $ProtectedIds,
+        [hashtable] $Reasons,
+        [switch] $IncludeAll
+    )
+    $rows = Invoke-Docker images --format '{{.ID}}|{{.Repository}}:{{.Tag}}|{{.Size}}|{{.CreatedSince}}'
+    $candidates = @()
+    foreach ($r in $rows) {
+        if ([string]::IsNullOrWhiteSpace($r)) { continue }
+        $parts = $r -split '\|'
+        $id = $parts[0]; $name = $parts[1]; $size = $parts[2]; $age = $parts[3]
+        if ($ProtectedIds.Contains($id)) {
+            Write-Log "  protect $id  $name  (reasons: $($Reasons[$id] -join '; '))" -Level DEBUG
+            continue
+        }
+        if (-not $IncludeAll -and $name -notmatch '<none>') {
+            # Standard mode: only remove unnamed (dangling) images by default.
+            # Named, unused images need Aggressive mode.
+            continue
+        }
+        $candidates += [pscustomobject]@{ Id = $id; Name = $name; Size = $size; Age = $age }
+    }
+
+    if ($candidates.Count -eq 0) {
+        Write-Log "No unused images to remove."
+        return @{ Count = 0; BytesFreed = 0L }
+    }
+
+    $totalBytes = ($candidates | ForEach-Object { ConvertFrom-DockerSize $_.Size } | Measure-Object -Sum).Sum
+    Write-Log "Removing $($candidates.Count) image(s), approx $(Format-Bytes $totalBytes):"
+    foreach ($c in $candidates) {
+        Write-Log "  - $($c.Id)  $($c.Name)  $($c.Size)  ($($c.Age))"
+    }
+    if ($DryRun) { Write-Log "  [DryRun] skipped removal"; return @{ Count = $candidates.Count; BytesFreed = 0L } }
+
+    $removed = 0
+    foreach ($c in $candidates) {
+        $out = & docker rmi $c.Id 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            $removed++
+            Write-Log "  removed $($c.Id)  $($c.Name)"
+        } else {
+            Write-Log "  could not remove $($c.Id)  $($c.Name): $out" -Level WARN
+        }
+    }
+    return @{ Count = $removed; BytesFreed = $totalBytes }
+}
+
+function Invoke-DockerPrune {
+    param(
+        [Parameter(Mandatory)][string] $Resource,
+        [switch] $All
+    )
+    $cmdArgs = @($Resource, 'prune', '--force')
+    if ($All) { $cmdArgs += '--all' }
+    Write-Log "docker $($cmdArgs -join ' ')"
+    if ($DryRun) { Write-Log "  [DryRun] skipped"; return 0L }
+    $out = & docker @cmdArgs 2>&1
+    $out | ForEach-Object { Write-Log "  $_" -Level DEBUG }
+    $reclaimedLine = $out | Where-Object { $_ -match '(?i)Total reclaimed space|reclaimed' } | Select-Object -Last 1
+    if ($reclaimedLine -and $reclaimedLine -match '([\d\.]+\s*[KMGT]?B)') {
+        $bytes = ConvertFrom-DockerSize $Matches[1]
+        Write-Log "  reclaimed $(Format-Bytes $bytes)"
+        return $bytes
+    }
+    return 0L
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+Write-Log "================================================================"
+Write-Log "Invoke-DockerCleanup starting (Mode=$Mode, DryRun=$DryRun, MaxAgeDays=$MaxAgeDays)"
+Write-Log "================================================================"
+
+# 1. Verify docker is reachable
+try {
+    $ver = & docker version --format '{{.Server.Version}}' 2>&1
+    if ($LASTEXITCODE -ne 0) { throw $ver }
+    Write-Log "Docker server $ver reachable."
+} catch {
+    Write-Log "Docker not reachable: $_" -Level ERROR
+    exit 2
+}
+
+# 2. Survey (always run)
+Write-Log "--- Survey ---"
+$before = Get-DockerSurvey
+foreach ($k in $before.Keys) {
+    $v = $before[$k]
+    Write-Log ("  {0,-14} total={1,4} active={2,4} size={3,-10} reclaimable={4}" -f $k, $v.Total, $v.Active, $v.Size, $v.Reclaimable)
+}
+
+if ($Mode -eq 'Survey') {
+    Write-Log "Survey-only mode; exiting without changes."
+    exit 0
+}
+
+# 3. Build protection set
+Write-Log "--- Computing protected images ---"
+$protected = Get-ProtectedImageIds
+Write-Log "Protected $($protected.Ids.Count) image(s)."
+
+# 4. Confirm
+if (-not (Confirm-Or-Exit "Proceed with '$Mode' cleanup")) {
+    Write-Log "User declined; exiting." -Level WARN
+    exit 0
+}
+
+# 5. Execute per-mode
+$summary = [ordered]@{
+    StaleContainersRemoved = 0
+    ImagesRemoved          = 0
+    BytesFreedImages       = 0L
+    BytesFreedCache        = 0L
+    BytesFreedVolumes      = 0L
+}
+
+$stale = Get-StaleContainers -OlderThanDays $MaxAgeDays
+$summary.StaleContainersRemoved = Remove-StaleContainers -Stale $stale
+
+# Unused networks (always safe — only removes those with no attached containers)
+$summary.BytesFreedImages += Invoke-DockerPrune -Resource 'network'
+
+if ($Mode -in 'Safe') {
+    $r = Remove-Images-Unused -ProtectedIds $protected.Ids -Reasons $protected.Reasons
+    $summary.ImagesRemoved   += $r.Count
+    $summary.BytesFreedImages += $r.BytesFreed
+}
+
+if ($Mode -in 'Standard', 'Aggressive') {
+    $includeAll = ($Mode -eq 'Aggressive')
+    $r = Remove-Images-Unused -ProtectedIds $protected.Ids -Reasons $protected.Reasons -IncludeAll:$includeAll
+    $summary.ImagesRemoved   += $r.Count
+    $summary.BytesFreedImages += $r.BytesFreed
+
+    if ($IncludeBuildCache) {
+        $summary.BytesFreedCache += Invoke-DockerPrune -Resource 'builder' -All
+    }
+}
+
+if ($Mode -eq 'Aggressive' -or ($Mode -eq 'Standard' -and $IncludeVolumes)) {
+    $summary.BytesFreedVolumes += Invoke-DockerPrune -Resource 'volume'
+}
+
+# 6. Final survey + summary
+Write-Log "--- Post-cleanup survey ---"
+$after = Get-DockerSurvey
+foreach ($k in $after.Keys) {
+    $v = $after[$k]
+    Write-Log ("  {0,-14} total={1,4} active={2,4} size={3,-10} reclaimable={4}" -f $k, $v.Total, $v.Active, $v.Size, $v.Reclaimable)
+}
+
+Write-Log "================================================================"
+Write-Log "RUN SUMMARY"
+Write-Log "  Stale containers removed: $($summary.StaleContainersRemoved)"
+Write-Log "  Images removed:           $($summary.ImagesRemoved)"
+Write-Log "  Bytes freed (images):     $(Format-Bytes $summary.BytesFreedImages)"
+Write-Log "  Bytes freed (cache):      $(Format-Bytes $summary.BytesFreedCache)"
+Write-Log "  Bytes freed (volumes):    $(Format-Bytes $summary.BytesFreedVolumes)"
+$total = $summary.BytesFreedImages + $summary.BytesFreedCache + $summary.BytesFreedVolumes
+Write-Log "  Total freed:              $(Format-Bytes $total)"
+Write-Log "================================================================"
+
+exit 0

--- a/.github/copilot/skills/docker-cleanup/SKILL.md
+++ b/.github/copilot/skills/docker-cleanup/SKILL.md
@@ -102,7 +102,7 @@ and exits 0. Use the output to:
 |---|---|
 | User just wants "the safe stuff" / first run | **Safe** |
 | Periodic maintenance / general "clean up Docker" / build cache is large | **Standard** (default for most asks) |
-| User explicitly wants maximum reclaim, or disk pressure is high | **Aggressive** + `-IncludeVolumes` |
+| User explicitly wants maximum reclaim, or disk pressure is high | **Aggressive** (volumes are always pruned; confirm first) |
 | Just curious / wants to see what would happen | **Standard** or **Aggressive** with `-DryRun` |
 
 ### Step 3: Identify protection scopes

--- a/.github/copilot/skills/docker-cleanup/SKILL.md
+++ b/.github/copilot/skills/docker-cleanup/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: docker-cleanup
+description: >-
+    Skill for reclaiming local Docker disk space — stale containers, unused
+    images, dangling networks, build cache, and (opt-in) volumes — via the
+    `Invoke-DockerCleanup.ps1` automation in this repository
+    (`.build\Invoke-DockerCleanup.ps1`). Use when the user mentions "clean up
+    docker", "docker disk space", "prune docker", "Invoke-DockerCleanup",
+    "remove stale containers/images", "reclaim disk", or asks to free up
+    Docker resources on this machine. Covers a survey-first preview, tiered
+    cleanup (Safe / Standard / Aggressive), auto-protection of in-use and
+    repo-referenced images, and a structured post-run summary.
+user-invocable: true
+---
+
+# Docker cleanup runbook
+
+This skill drives **`.build\Invoke-DockerCleanup.ps1`** (relative to this
+repository's root), a safety-first PowerShell tool that surveys local Docker
+disk usage and removes stale resources in three escalating tiers. The full
+runbook is at [`docs/DockerCleanup.md`](../../../../docs/DockerCleanup.md).
+
+The script auto-protects images that are currently in use; the skill layers
+**repo awareness** and **kubectl context awareness** on top so you don't have
+to remember which compose files or clusters depend on which images.
+
+## When to use this skill
+
+Trigger when the user asks to:
+
+- "Clean up Docker" / "free up Docker disk space" / "reclaim disk"
+- "Prune docker images/containers/cache"
+- "Remove stale/exited containers" / "delete unused images"
+- "Run DockerCleanup" / "Invoke-DockerCleanup"
+- Investigate where Docker disk usage is going
+
+Do NOT use this skill for:
+
+- Stopping or removing **running** containers — those are user-managed
+- Removing images in **remote** registries (use `container-security-upgrade`
+  for ACR work, or the registry's own UI/CLI)
+- Cleaning Docker artifacts inside a container (devcontainer-in-DinD has its
+  own daemon — this skill only sees the host)
+
+## Repo / paths
+
+| Thing | Repo-relative |
+|---|---|
+| Script | `.build\Invoke-DockerCleanup.ps1` |
+| Runbook | `docs\DockerCleanup.md` |
+| Log file (created on first run; gitignored) | `.build\docker_cleanup.log` |
+
+To resolve the script reliably regardless of cwd, prefer
+`Resolve-Path (Join-Path $RepoRoot '.build\Invoke-DockerCleanup.ps1')`.
+If you're already standing in the repo root, just use
+`.\.build\Invoke-DockerCleanup.ps1`.
+
+## Prerequisite checks (always do these first)
+
+```powershell
+# 1. Docker daemon reachable?
+docker version --format 'Client: {{.Client.Version}} | Server: {{.Server.Version}}'
+
+# 2. Script visible? (cwd assumed to be repo root)
+Test-Path '.\.build\Invoke-DockerCleanup.ps1'
+
+# 3. Active kubectl context (for protection logic)?
+kubectl config current-context
+```
+
+Resolution table:
+
+| Failure | Fix |
+|---|---|
+| Docker daemon not running | Start Docker Desktop: `Start-Process "C:\Program Files\Docker\Docker\Docker Desktop.exe" -ArgumentList "-Autostart"` and poll `docker version` for up to 120s. Don't proceed until the server responds. |
+| Script path missing | Either the cwd isn't the repo root, or you're in a different repo. `git rev-parse --show-toplevel` to confirm. If you're in another repo, either `cd` to a clone of this repo, or stop and tell the user. |
+| `kubectl` not installed | Fine — the script will skip K8s protection automatically. Note this in the report. |
+
+## Recommended workflow
+
+Always run a Survey first, then escalate. Do not jump straight to Aggressive.
+
+### Step 1: Survey (mandatory)
+
+```powershell
+# from the repo root
+.\.build\Invoke-DockerCleanup.ps1
+```
+
+This runs `docker system df` plus a per-resource breakdown, makes no changes,
+and exits 0. Use the output to:
+
+1. Read the totals (Images / Containers / Volumes / Build cache) and the
+   per-type **reclaimable** number.
+2. Identify the biggest fish: usually devcontainer images, build cache, or
+   stale compose stacks.
+3. Decide which mode to recommend (see decision table below).
+
+### Step 2: Decide the mode
+
+| Situation | Recommend |
+|---|---|
+| User just wants "the safe stuff" / first run | **Safe** |
+| Periodic maintenance / general "clean up Docker" / build cache is large | **Standard** (default for most asks) |
+| User explicitly wants maximum reclaim, or disk pressure is high | **Aggressive** + `-IncludeVolumes` |
+| Just curious / wants to see what would happen | **Standard** or **Aggressive** with `-DryRun` |
+
+### Step 3: Identify protection scopes
+
+Before running the cleanup, look up:
+
+1. **Active repos with compose files.** Always pass the current repo via
+   `-RepoPath` so its `docker-compose*.yml`-referenced images are protected.
+   For this repo specifically, that includes `rust-api`, `csharp-api`,
+   `worker-service`, `rabbitmq:4.1-management`, and any pinned base images.
+   - Quick check: `Get-ChildItem -Recurse -File -Include 'docker-compose*.yml','compose*.yml' -ErrorAction SilentlyContinue | Select-Object FullName`
+   - Default to passing `$PWD` if it's the repo root.
+   - If the user is also working in other repos with their own compose stacks,
+     pass them too: `-RepoPath $PWD,'E:\Code\OtherRepo'`.
+
+2. **Active kubectl context.** If `kubectl config current-context` is
+   `docker-desktop`, the script auto-protects Docker Desktop K8s images. For
+   `kind-*` / `minikube` contexts, the script does NOT auto-detect — pass the
+   relevant image patterns via `-IgnoreImage`, e.g.:
+   ```
+   -IgnoreImage '^kindest/node','^k8s\.gcr\.io/','^registry\.k8s\.io/'
+   ```
+
+3. **Anything the user explicitly told you to keep.** E.g. a custom base
+   image they're iterating on. Add to `-IgnoreImage` as a regex.
+
+> **Implicit auto-protections** (no flag needed): images bound to any
+> container (running or not); `mcr.microsoft.com/devcontainers/*` whenever a
+> `vsc-*` devcontainer image is present locally (Docker can't see a child
+> image's `FROM` chain, so Aggressive mode would otherwise delete the multi-GB
+> devcontainer base out from under VS Code).
+
+### Step 4: Execute
+
+```powershell
+.\.build\Invoke-DockerCleanup.ps1 `
+    -Mode Standard `
+    -RepoPath $PWD `
+    -MaxAgeDays 30
+```
+
+The script will prompt for confirmation unless `-Force` is given. In
+autonomous/scheduled mode pass `-Force`; otherwise allow the prompt.
+
+### Step 5: Verify and report
+
+After the script exits:
+
+1. Read the boxed `RUN SUMMARY` from the tail of the log:
+   ```powershell
+   Get-Content '.\.build\docker_cleanup.log' -Tail 60
+   ```
+2. Run `docker system df` to confirm the new totals.
+3. Confirm the running devcontainer (or whatever the user cares about) is
+   still up: `docker ps`.
+
+Then synthesize a short markdown report for the user:
+
+```
+Docker cleanup @ <timestamp>  (Mode=<mode>)
+Reclaimed: <total>
+  Images:   <bytes> across <N> removed
+  Cache:    <bytes>
+  Volumes:  <bytes>
+Stale containers removed: <N>
+Now using: <total GB> across <image count> images
+Protected: <reason summary>
+```
+
+## Modes (quick reference)
+
+| Mode | Removes containers (exited > MaxAgeDays) | Removes dangling images | Removes unused unnamed images | Removes unused named images | Prunes build cache | Prunes volumes |
+|---|---|---|---|---|---|---|
+| Survey | — | — | — | — | — | — |
+| Safe | ✓ | ✓ | — | — | — | — |
+| Standard | ✓ | ✓ | ✓ | — | ✓ (if `-IncludeBuildCache`) | only if `-IncludeVolumes` |
+| Aggressive | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ (always) |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `docker not reachable` exit 2 | Docker Desktop not started, or WSL2 backend not ready | Start Docker Desktop, wait for it to be healthy, retry |
+| `Error response from daemon: conflict: unable to delete <id>` | Image is referenced by a stopped container the script didn't classify as stale (e.g. younger than `-MaxAgeDays`) | Lower `-MaxAgeDays`, or `docker rm <container>` manually first |
+| `image is being used by running container` | Auto-protection should have caught it; if it didn't, the container started after the protection scan | Re-run the script |
+| `volume in use` during prune | A stopped (but recent) container still references it | The volume prune skips it — safe; revisit later |
+| Compose-referenced image got deleted anyway | The compose file path wasn't passed via `-RepoPath`, or the image isn't pulled locally yet | Re-pull (`docker compose pull`) — protection only works on *locally present* images |
+
+## Scheduled / unattended runs
+
+When invoked from a scheduled prompt or by autopilot:
+
+- Always start with **Survey**. If the survey shows < 1 GB reclaimable, stop
+  and report — there is nothing to do.
+- Use `-Force` to skip the confirmation prompt.
+- Default to `-Mode Standard` for routine maintenance. Only escalate to
+  Aggressive if the user has previously asked for it or disk pressure is acute.
+- Never use `-IncludeVolumes` unattended without the user having explicitly
+  opted in beforehand — losing a volume is the worst-case outcome of this skill.
+- Always pass `-RepoPath $PWD` from a clone of this repo so its compose
+  stacks are protected.
+
+## Things this skill must not do
+
+- **Don't touch running containers.** The skill only ever removes resources
+  in exited / dead / dangling states. If the user wants to stop something,
+  they ask explicitly.
+- **Don't delete volumes by default.** Volume removal is opt-in via
+  `-IncludeVolumes`, and even then must be flagged in the user-facing summary.
+- **Don't bypass the protection logic.** If a user asks "just delete
+  everything", confirm the request and use `-Mode Aggressive -IncludeVolumes
+  -Force`, but never edit the protection lists at runtime.
+- **Don't restart Docker Desktop unattended** to "fix" cleanup failures.
+  Surface the failure and let the user decide.
+- **Don't run on remote daemons.** This is a workstation-cleanup tool. If
+  `DOCKER_HOST` is set to a remote engine, stop and confirm with the user.

--- a/.github/copilot/skills/docker-cleanup/SKILL.md
+++ b/.github/copilot/skills/docker-cleanup/SKILL.md
@@ -210,11 +210,10 @@ When invoked from a scheduled prompt or by autopilot:
 - **Don't touch running containers.** The skill only ever removes resources
   in exited / dead / dangling states. If the user wants to stop something,
   they ask explicitly.
-- **Don't delete volumes by default.** Volume removal is opt-in via
-  `-IncludeVolumes`, and even then must be flagged in the user-facing summary.
+- **Don't delete volumes by default in Standard mode.** Volume removal is opt-in via
+  `-IncludeVolumes`; **Aggressive always prunes unused volumes**, so only recommend it after explicit user confirmation and flag it in the summary.
 - **Don't bypass the protection logic.** If a user asks "just delete
-  everything", confirm the request and use `-Mode Aggressive -IncludeVolumes
-  -Force`, but never edit the protection lists at runtime.
+  everything", confirm the request and use `-Mode Aggressive -Force`, but never edit the protection lists at runtime.
 - **Don't restart Docker Desktop unattended** to "fix" cleanup failures.
   Surface the failure and let the user decide.
 - **Don't run on remote daemons.** This is a workstation-cleanup tool. If

--- a/docs/DockerCleanup.md
+++ b/docs/DockerCleanup.md
@@ -1,0 +1,125 @@
+# Docker Cleanup Runbook
+
+## Overview
+
+This document describes the process for reclaiming local Docker disk space on
+a developer workstation — stale containers, unreferenced images, dangling
+networks, build cache, and (opt-in) unused volumes — using the
+[`Invoke-DockerCleanup.ps1`](../.build/Invoke-DockerCleanup.ps1) automation.
+
+The script is safety-first: it always runs a survey by default, supports a
+dry-run flag, and auto-protects images that are in use by containers,
+referenced by this repo's `docker-compose*.yml` files, or part of the running
+devcontainer / Docker Desktop Kubernetes stack.
+
+A companion [Copilot CLI skill](../.github/copilot/skills/docker-cleanup/SKILL.md)
+drives this script with contextual checks and produces a structured post-run
+summary.
+
+## Quick start
+
+```powershell
+# Survey only — no changes (always safe to run)
+.\.build\Invoke-DockerCleanup.ps1
+
+# Recommended cleanup, protecting images referenced by this repo's compose files
+.\.build\Invoke-DockerCleanup.ps1 -Mode Standard -RepoPath $PWD
+
+# Maximum cleanup, unattended
+.\.build\Invoke-DockerCleanup.ps1 -Mode Aggressive -IncludeVolumes -Force
+
+# Preview an aggressive cleanup without touching anything
+.\.build\Invoke-DockerCleanup.ps1 -Mode Aggressive -IncludeVolumes -DryRun
+```
+
+## Modes
+
+| Mode | Containers | Images | Build cache | Volumes |
+|---|---|---|---|---|
+| **Survey** (default) | report only | report only | report only | report only |
+| **Safe** | exited > `-MaxAgeDays` | dangling only | — | — |
+| **Standard** | exited > `-MaxAgeDays` | dangling + unused unnamed | pruned (`-IncludeBuildCache`) | only if `-IncludeVolumes` |
+| **Aggressive** | exited > `-MaxAgeDays` | **all unused** (incl. named) | pruned | **pruned always** |
+
+The "stale containers" filter requires a container to be older than
+`-MaxAgeDays` (default 30) **and** in exited / dead / created state.
+
+## Auto-protection
+
+The script protects images from removal when any of the following apply.
+Override with `-SkipKubectlProtection` (for kubectl) or by omitting `-RepoPath`.
+
+| Source | What it protects |
+|---|---|
+| `docker ps -a` | Every image currently bound to a container (running or stopped) |
+| `-RepoPath` | Every image referenced as `image: foo:tag` in `docker-compose*.yml` / `compose*.yml` under the path |
+| `docker images` shows a `vsc-*` image (VS Code devcontainer build) | Auto-protects `mcr.microsoft.com/devcontainers/*` base images — Docker can't walk a child image's `FROM` chain, so without this Aggressive mode would delete the (14+ GB) base on its own |
+| `kubectl config current-context` = `docker-desktop` | Images matching `registry.k8s.io/*`, `docker/desktop-*`, `kindest/node`, `envoyproxy/envoy` |
+| `-IgnoreImage <regex>` | Manual user override (any image whose `repo:tag` or ID matches) |
+
+## Parameters
+
+| Name | Type | Default | Notes |
+|---|---|---|---|
+| `-Mode` | string | `Survey` | One of `Survey`, `Safe`, `Standard`, `Aggressive` |
+| `-DryRun` | switch | off | Prints every planned action without executing |
+| `-Force` | switch | off | Skip the confirmation prompt |
+| `-MaxAgeDays` | int | `30` | Stale-container age cutoff |
+| `-IncludeVolumes` | switch | off | Allow volume prune in Standard mode |
+| `-IncludeBuildCache` | bool | `$true` | Prune build cache in Standard/Aggressive |
+| `-RepoPath` | string[] | `@()` | Repo(s) whose compose files protect images |
+| `-IgnoreImage` | string[] | `@()` | Regex patterns to protect |
+| `-SkipKubectlProtection` | switch | off | Disable Docker Desktop K8s auto-protection |
+
+## Output
+
+- All actions append to `docker_cleanup.log` next to the script in `.build\`
+  (~5 MB rotation, 5 backups). The log file is excluded by `.gitignore`.
+- Console output mirrors the log with color-coded INFO / WARN / ERROR.
+- A boxed `RUN SUMMARY` is emitted at the end with counts and bytes reclaimed.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Survey complete, or cleanup ran (possibly with per-item warnings) |
+| `2` | Docker daemon not reachable — nothing attempted |
+
+## Safety notes
+
+- **Volumes are opt-in.** Standard mode never touches them unless
+  `-IncludeVolumes` is given; Aggressive always prunes unused volumes (warn
+  the user).
+- **Build cache is pruned aggressively.** `docker builder prune --all --force`
+  removes everything not currently in use; this is normally what you want but
+  can slow down the very next `docker build` because layers must be re-downloaded.
+- **kubectl context detection** is best-effort. If you use a non-`docker-desktop`
+  cluster (kind, minikube, AKS) and want its images protected, pass them via
+  `-IgnoreImage`. The script does not run `kubectl get pods` to enumerate
+  in-use images.
+- The script never elevates and never restarts Docker Desktop.
+
+## Recommended workflow for this repo
+
+Because this repository is the active home of several long-lived compose
+stacks (`docker-compose.yml`, `docker-compose.api.yml`, etc.) and a
+devcontainer, always pass `-RepoPath` so its compose-referenced images
+(`rust-api`, `csharp-api`, `worker-service`, `rabbitmq:4.1-management`,
+`postgres:*`, etc.) are protected from Aggressive mode.
+
+```powershell
+# From the repo root
+.\.build\Invoke-DockerCleanup.ps1 `
+    -Mode Standard `
+    -RepoPath $PWD `
+    -MaxAgeDays 30
+```
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `.build\Invoke-DockerCleanup.ps1` | The automation script |
+| `.build\docker_cleanup.log[.1-.5]` | Rotated run log (created on first run, gitignored) |
+| `.github\copilot\skills\docker-cleanup\SKILL.md` | Copilot CLI skill that drives the script |
+| `docs\DockerCleanup.md` | This runbook |

--- a/docs/DockerCleanup.md
+++ b/docs/DockerCleanup.md
@@ -38,7 +38,7 @@ summary.
 |---|---|---|---|---|
 | **Survey** (default) | report only | report only | report only | report only |
 | **Safe** | exited > `-MaxAgeDays` | dangling only | — | — |
-| **Standard** | exited > `-MaxAgeDays` | dangling + unused unnamed | pruned (`-IncludeBuildCache`) | only if `-IncludeVolumes` |
+| **Standard** | exited > `-MaxAgeDays` | dangling only | pruned (`-IncludeBuildCache`) | only if `-IncludeVolumes` |
 | **Aggressive** | exited > `-MaxAgeDays` | **all unused** (incl. named) | pruned | **pruned always** |
 
 The "stale containers" filter requires a container to be older than


### PR DESCRIPTION
## Summary

Adds **Invoke-DockerCleanup.ps1** — a tiered, safety-first PowerShell automation for reclaiming local Docker disk space — plus its companion runbook and Copilot CLI skill, all colocated with this repository's existing automation conventions.

## What's included

| File | Purpose |
|---|---|
| `.build\Invoke-DockerCleanup.ps1` | The automation script (~520 lines) |
| `docs\DockerCleanup.md` | Runbook matching `ContainerSecurityUpgrade.md` style |
| `.github\copilot\skills\docker-cleanup\SKILL.md` | Repo-scoped Copilot CLI skill that drives the script with contextual checks |

Placement mirrors the existing `Upgrade-ContainerImages.ps1` / `ContainerSecurityUpgrade.md` pair.

## Modes

| Mode | Containers | Images | Build cache | Volumes |
|---|---|---|---|---|
| `Survey` (default) | report only | report only | report only | report only |
| `Safe` | exited > `-MaxAgeDays` | dangling only | — | — |
| `Standard` | exited > `-MaxAgeDays` | dangling + unused unnamed | pruned | only if `-IncludeVolumes` |
| `Aggressive` | exited > `-MaxAgeDays` | **all unused** | pruned | **pruned always** |

## Auto-protection

The script refuses to delete any image that is:

1. **Bound to a container** (running or stopped)
2. **Referenced by a `docker-compose*.yml`** under any `-RepoPath` — protects this repo's `rust-api`, `csharp-api`, `worker-service`, `rabbitmq:4.1-management` etc.
3. **`mcr.microsoft.com/devcontainers/*`** whenever a `vsc-*` devcontainer image is present locally — Docker can't walk a child image's `FROM` chain, so without this Aggressive mode would happily delete the multi-GB devcontainer base out from under VS Code
4. **Docker Desktop K8s images** (`registry.k8s.io/*`, `docker/desktop-*`, `kindest/node`, `envoyproxy/envoy`) when current `kubectl` context is `docker-desktop`
5. Anything matching `-IgnoreImage <regex[]>`

## Verification

Validated end-to-end against the live workstation from the new location:

- ✅ `Survey` mode — read-only summary works
- ✅ `Standard -DryRun -RepoPath \E:\Code\RustAksDemoLab` from this repo — planned correctly, made no changes
- ✅ vsc-* auto-protection triggered (14 images protected)
- ✅ `docker-desktop` kubectl context detected and protected
- ✅ Runtime log written to `.build\docker_cleanup.log` and excluded by existing `*.log` rule in `.gitignore`

Earlier in development this script caught and fixed a real bug where Aggressive mode would have nuked a running devcontainer's 14.9 GB `mcr.microsoft.com/devcontainers/universal:6` base; the vsc-* auto-protection in this PR is the fix.

## Notes

- Always start with `Survey`; never jump straight to Aggressive
- Build cache prune is enabled by default in Standard / Aggressive (`-IncludeBuildCache:$true`); disable explicitly if needed
- Volume removal is opt-in via `-IncludeVolumes` (Standard) and forced in Aggressive
- The skill will be discovered by Copilot CLI whenever a clone of this repo is the cwd

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
